### PR TITLE
Handle missing version metadata

### DIFF
--- a/pybliometrics/__init__.py
+++ b/pybliometrics/__init__.py
@@ -1,6 +1,9 @@
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("pybliometrics")
+try:
+    __version__ = version("pybliometrics")
+except PackageNotFoundError:  # pragma: no cover - executed when package metadata is missing
+    __version__ = "0.0.0"
 
 __citation__ = (
     'Rose, Michael E. and John R. Kitchin: "pybliometrics: '

--- a/pybliometrics/tests/test_version.py
+++ b/pybliometrics/tests/test_version.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+from importlib import metadata
+from unittest import mock
+
+
+def test_version_fallback():
+    """Package reports fallback version when metadata is missing."""
+    sys.modules.pop("pybliometrics", None)
+    with mock.patch("importlib.metadata.version", side_effect=metadata.PackageNotFoundError):
+        module = importlib.import_module("pybliometrics")
+        assert module.__version__ == "0.0.0"
+    sys.modules.pop("pybliometrics", None)
+    importlib.import_module("pybliometrics")


### PR DESCRIPTION
## Summary
- make importing pybliometrics robust if package metadata isn't installed
- add regression test for missing metadata

## Testing
- `pip install tqdm requests urllib3`
- `pytest pybliometrics/tests/test_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eac59f64833197f5f850ff36e8d0